### PR TITLE
Fix readme file tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ Datathon/
 │   └── [outputs]
 ├── README.md   # this file
 ├── Canes.pptx  # presentation slides
-├── requirements.txt # environment requirements
-└── problem_statement.markdown # summary of the problems
+└── requirements.txt # environment requirements
 
 ```
 


### PR DESCRIPTION
## Summary
- correct file tree to remove non-existent `problem_statement.markdown`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fb0ab91008328be7e56c99e8e20c7